### PR TITLE
Standardise driver creation

### DIFF
--- a/lib/automation_helpers/drivers/v4/browserstack.rb
+++ b/lib/automation_helpers/drivers/v4/browserstack.rb
@@ -14,10 +14,7 @@ module AutomationHelpers
       # This requires a series of pre-set values to be passed in
       #
       class Browserstack
-        attr_reader :browser, :browserstack_options, :device_options
-        private :browser, :browserstack_options, :device_options
-
-        attr_writer :options
+        attr_reader :browser, :browserstack_options, :device_options, :options
 
         # #### Initial setup options
         #
@@ -33,13 +30,15 @@ module AutomationHelpers
         #     i.e. Windows_10_92 means run on Windows Operating System, OS Version 10, Browser Version 92
         #   - :username (String)                 -> The username for Browserstack
         #   - :api_key (String)                  -> The api key for Browserstack
-        #
-        # #### Post initialization setup options
+        # - **device_options** (optional)        - A Hash of all device specific options that can customise your device
+        #   - :device_name (String)              -> The name of your device
+        #   - :os_version (String)               -> The operating system for your device
         # - **options** (optional) -> You can instantiate an Options payload that can be used when registering your driver
-        def initialize(browser, browserstack_options, device_options = {})
+        def initialize(browser, browserstack_options, device_options = {}, options = Options.for(browser))
           @browser = browser
           @browserstack_options = browserstack_options
           @device_options = device_options
+          @options = options
         end
 
         # @return [Nil]
@@ -106,10 +105,6 @@ module AutomationHelpers
           return {} if device?
 
           { 'browserVersion' => browser_version }
-        end
-
-        def options
-          @options ||= Options.for(browser)
         end
 
         def browserstack_hub_url

--- a/lib/automation_helpers/drivers/v4/local.rb
+++ b/lib/automation_helpers/drivers/v4/local.rb
@@ -12,7 +12,6 @@ module AutomationHelpers
       #
       class Local
         attr_reader :browser, :options
-        private :browser
 
         # #### Initial setup options
         #

--- a/lib/automation_helpers/drivers/v4/remote.rb
+++ b/lib/automation_helpers/drivers/v4/remote.rb
@@ -11,19 +11,15 @@ module AutomationHelpers
       # This expects the grid to be live **and** accepting node requests
       #
       class Remote
-        attr_reader :browser
-        private :browser
-
-        attr_writer :options
+        attr_reader :browser, :options
 
         # #### Initial setup options
         #
         # - **browser** (required) - When instantiating, the first argument must be the symbol that represents what browser to use
+        # - **options** (optional) -> You can instantiate an Options payload that can be used when registering your driver
+        #
         # - **ENV["HUB_URL"]** (required) - The environment variable HUB_URL must be set to the actively running dockerized grid
         #   (By default this should be +http://hub:4444/wd/hub+)
-        #
-        # #### Post initialization setup options
-        # - **options** (optional) -> You can instantiate an Options payload that can be used when registering your driver
         def initialize(browser)
           @browser = browser
         end

--- a/lib/automation_helpers/drivers/v4/remote.rb
+++ b/lib/automation_helpers/drivers/v4/remote.rb
@@ -20,8 +20,9 @@ module AutomationHelpers
         #
         # - **ENV["HUB_URL"]** (required) - The environment variable HUB_URL must be set to the actively running dockerized grid
         #   (By default this should be +http://hub:4444/wd/hub+)
-        def initialize(browser)
+        def initialize(browser, options = Options.for(browser))
           @browser = browser
+          @options = options
         end
 
         # @return [Nil]
@@ -44,10 +45,6 @@ module AutomationHelpers
           raise ArgumentError, 'You must use a supported browser' unless supported_browser?
 
           Capabilities.for(browser)
-        end
-
-        def options
-          @options ||= Options.for(browser)
         end
 
         def hub_url


### PR DESCRIPTION
- Set all iVars to public readers and standardise creation
- Permit device options to be customised