### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/site-prism/automation_helpers/security/code-scanning/1](https://github.com/site-prism/automation_helpers/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, directly under the `on:` section (or under `name:`), so it applies to all jobs unless overridden.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI tasks while avoiding unnecessary write scopes. No new imports, methods, or dependencies are needed—just YAML configuration change in the existing file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
